### PR TITLE
feat: 페이지 목록 조회 구현

### DIFF
--- a/public/api/postListApi.js
+++ b/public/api/postListApi.js
@@ -1,0 +1,7 @@
+import { authClient } from "./apiClient.js";
+
+export const getPostlist = async (path) => {
+  const res = await authClient.get(path);
+  const data = await res.json();
+  return data.data;
+};

--- a/public/pages/post-list/post-list.html
+++ b/public/pages/post-list/post-list.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/semantics/main/main.css" />
     <link rel="stylesheet" href="/pages/post-list/post-list.css" />
     <script defer type="module" src="/semantics/common.js"></script>
+    <script defer type="module" src="/pages/post-list/post-list.js"></script>
   </head>
   <body>
     <header id="app-header"></header>
@@ -23,8 +24,7 @@
 
       <!-- 리스트 -->
       <section class="post-list" id="postList">
-        <!-- 카드 1개 예시 (반복) -->
-        <article class="post-card">
+        <!-- <article class="post-card">
           <div class="card-head">
             <h3 class="title">제목 1</h3>
             <time class="time">2021-01-01 00:00:00</time>
@@ -40,10 +40,16 @@
             <span class="avatar"></span>
             <span class="author">더미 작성자 1</span>
           </div>
-        </article>
+        </article> -->
 
         <!-- 필요 시 더 많은 카드가 이어짐 -->
       </section>
+      <div id="sentinel" aria-hidden="true">
+        <div id="loader">...로딩 중...</div>
+        <div id="end-of-list" style="display: none">
+          ...더 이상 데이터가 없습니다...
+        </div>
+      </div>
     </main>
   </body>
 </html>

--- a/public/pages/post-list/post-list.js
+++ b/public/pages/post-list/post-list.js
@@ -1,0 +1,113 @@
+import { getPostlist } from "../../api/postListApi.js";
+
+const endNode = document.getElementById("sentinel");
+const pNode = document.getElementById("postList");
+
+// a 태그로 화면전환 or click 이벤트 넣기
+const createTemplate = ({
+  postId,
+  title,
+  createdAt,
+  likeCount,
+  commentCount,
+  clickCount,
+  userId,
+  authNickname,
+}) => `<article class="post-card" id="post_${postId}">
+          <div class="card-head" >
+            <h3 class="title">${title}</h3>
+            <time class="time">${createdAt}</time>
+          </div>
+
+          <div class="meta">
+            <span>좋아요 ${likeCount}</span>
+            <span>댓글 ${commentCount}</span>
+            <span>조회수 ${clickCount}</span>
+          </div>
+
+          <div class="card-foot">
+            <span class="avatar"></span>
+            <span class="author" id="user_${userId}">${authNickname}</span>
+          </div>
+        </article>`;
+
+function checkNullAndUndefind(json) {
+  return Object.entries(json).filter((e) => {
+    const v = e[1];
+    if (v === undefined || v === null) return false;
+    try {
+      parseInt(v);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function arrayToJson(array) {
+  const rtn = {};
+  array.forEach((e) => {
+    rtn[e[0]] = e[1];
+  });
+  return rtn;
+}
+
+function removeInvalidJson(json) {
+  return arrayToJson(checkNullAndUndefind(json));
+}
+
+let lastReadId = null;
+let limit = 3;
+let hasNext = true;
+let observer = new IntersectionObserver(observeLoadFetch);
+observer.observe(endNode);
+let isLoading = false;
+
+async function loadAndFetch() {
+  if (!hasNext) return;
+  const paramValues = { lastReadId, limit };
+
+  const params = new URLSearchParams(removeInvalidJson(paramValues));
+  const dto = await getPostlist(`/posts?${params}`);
+
+  function calcTimeInCurrentTz(time) {
+    let createdAt = new Date(time).toLocaleString();
+    return createdAt;
+  }
+  dto.posts.forEach((ele) => {
+    const postCard = document.createElement("article");
+    let user = ele.authorThumbNailDto;
+    let template = createTemplate({
+      postId: ele.postId,
+      title: ele.title,
+      likeCount: ele.postLike,
+      commentCount: ele.commentCount,
+      clickCount: ele.clickCount,
+      userId: user.userId,
+      authNickname: user.authorNickname,
+      createdAt: calcTimeInCurrentTz(ele.createdAt),
+      thumbNailPath: ele.thumbNailPath,
+    });
+
+    postCard.className = "post-card";
+    postCard.innerHTML = template;
+    pNode.appendChild(postCard);
+  });
+  console.log(dto);
+  hasNext = dto.hasNext;
+  if (hasNext) {
+    lastReadId = dto.lastPostId || null;
+  }
+}
+
+// 지금은 더 불러올 것이 없다면, 더이상 불러올 수 없는 상황이 됨.
+// 추후 폴링이나, http 이외의 프로토콜을 쓴다면 상태 갱신으로 가능할듯.
+async function observeLoadFetch(entries) {
+  console.log(entries, isLoading);
+  if (!entries[0].isIntersecting || isLoading) return;
+  isLoading = true;
+  await loadAndFetch();
+  isLoading = false;
+}
+
+document.addEventListener("DOMContentLoaded", loadAndFetch);


### PR DESCRIPTION
- post-list.html postlist의 끝단을 기준으로 무한스크롤 함수 실행
- 첫 기준을 size = 3, 시작 idx = null로 잡아, 서버에서 넘어온 값을 갱신하는 방식의 커서 방법으로 무한스크롤 구현
- post-list.js에 dto 매핑, api 호출, 이벤트 리스너 추가 로직 구현
- postListApi.js에 fetch메서드 작성